### PR TITLE
Why not give user ability to ask the type openly?

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -14,14 +14,14 @@
 
   var types = 'Array Object String Date RegExp Function Boolean Number Null Undefined'.split(' ');
 
-  function type() {
-    return Object.prototype.toString.call(this).slice(8, -1);
+  axis.type = function(item) {
+    return Object.prototype.toString.call(item).slice(8, -1);
   }
 
   for (var i = types.length; i--;) {
     axis['is' + types[i]] = (function (self) {
       return function (elem) {
-        return type.call(elem) === self;
+        return axis.type(elem) === self;
       };
     })(types[i]);
   }


### PR DESCRIPTION
Now you can actually ask axis what IS the item :) instead of just comparing.

No reason to hide a method that already exists there anyways.