### PR TITLE
Created TypeScript Type definition file and added axis.type()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ axis.isUndefined(); // true
 npm install axis.js
 ```
 
+## Using with Node.js / TypeScript
+```typescript
+import { axis } from 'axis.js';
+```
+
 ## Installing with Bower
 Use the repository hook:
 
@@ -42,18 +47,13 @@ Ensure you're using the files from the `dist` directory (contains compiled produ
 </body>
 ```
 
-## Using with Node.js / TypeScript
-```typescript
-import { axis } from 'axis.js';
-```
-
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using Gulp.
 
 ## Release history
 
 - 1.3.0
-  - Add axis.js.d.ts to enable `import` in TypeScript, thanks [glitch452](https://github.com/glitch452/)
+  - Add `axis.js.d.ts` to enable `import` in TypeScript, thanks [glitch452](https://github.com/glitch452/)
   - Add `axis.type()` function, thanks [agrublev](https://github.com/agrublev/)
 - 1.2.1
   - Add `main` in `package.json`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Ensure you're using the files from the `dist` directory (contains compiled produ
 </body>
 ```
 
+## Using with Node.js / TypeScript
+```typescript
+import { axis } from 'axis.js';
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using Gulp.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install axis.js
 
 ## Using with Node.js / TypeScript
 ```typescript
-import { axis } from 'axis.js';
+import axis from 'axis.js';
 ```
 
 ## Installing with Bower

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A super-simple &lt;1KB type checking module for JavaScript that returns a `Boolean` for each type check.
 
 ```js
+axis.type("example") // "String"
 axis.isArray([]); // true
 axis.isObject({}); // true
 axis.isString(''); // true
@@ -51,6 +52,9 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release history
 
+- 1.3.0
+  - Add axis.js.d.ts to enable `import` in TypeScript, thanks [glitch452](https://github.com/glitch452/)
+  - Add `axis.type()` function, thanks [agrublev](https://github.com/agrublev/)
 - 1.2.1
   - Add `main` in `package.json`
 - 1.2.0

--- a/dist/axis.d.ts
+++ b/dist/axis.d.ts
@@ -1,12 +1,12 @@
 // Type definitions for axis.js
 // Project: axis.js
-// Definitions by: glitch452
 // Project by: toddmotto
+// Definitions by: glitch452
 
 /**
- * Usage: import { axis } from 'axis.js';
+ * Usage: import axis from 'axis.js';
  */
-export namespace axis {
+declare namespace axis {
 
     /**
      * axis.type( "item" ); // "String"
@@ -64,3 +64,5 @@ export namespace axis {
     export function isUndefined(elem: any): boolean;
 
 }
+
+export = axis;

--- a/dist/axis.js
+++ b/dist/axis.js
@@ -1,4 +1,4 @@
-/*! axis.js v1.2.1 | (c) 2016 @toddmotto | https://github.com/toddmotto/axis */
+/*! axis.js v1.3.0 | (c) 2016 @toddmotto | https://github.com/toddmotto/axis */
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define([], factory);
@@ -15,14 +15,14 @@
 
   var types = 'Array Object String Date RegExp Function Boolean Number Null Undefined'.split(' ');
 
-  function type() {
-    return Object.prototype.toString.call(this).slice(8, -1);
+  axis.type = function(item) {
+    return Object.prototype.toString.call(item).slice(8, -1);
   }
 
   for (var i = types.length; i--;) {
     axis['is' + types[i]] = (function (self) {
       return function (elem) {
-        return type.call(elem) === self;
+        return axis.type(elem) === self;
       };
     })(types[i]);
   }

--- a/dist/axis.js.d.ts
+++ b/dist/axis.js.d.ts
@@ -3,10 +3,15 @@
 // Definitions by: glitch452
 // Project by: toddmotto
 
-/*
+/**
  * Usage: import { axis } from 'axis.js';
  */
 export namespace axis {
+
+    /**
+     * axis.type( "item" ); // "String"
+     */
+    export function type(elem: any): string;
 
     /**
      * axis.isArray( [] ); // true

--- a/dist/axis.js.d.ts
+++ b/dist/axis.js.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for axis.js
+// Project: axis.js
+// Definitions by: glitch452
+// Project by: toddmotto
+
+/*
+ * Usage: import { axis } from 'axis.js';
+ */
+export namespace axis {
+
+    /**
+     * axis.isArray( [] ); // true
+     */
+    export function isArray(elem: any): boolean;
+
+    /**
+     * axis.isObject( {} ); // true
+     */
+    export function isObject(elem: any): boolean;
+
+    /**
+     * axis.isString( '' ); // true
+     */
+    export function isString(elem: any): boolean;
+
+    /**
+     * axis.isDate( new Date() ); // true
+     */
+    export function isDate(elem: any): boolean;
+
+    /**
+     * axis.isRegExp( /test/i ); // true
+     */
+    export function isRegExp(elem: any): boolean;
+
+    /**
+     * axis.isFunction( function () {} ); // true
+     */
+    export function isFunction(elem: any): boolean;
+
+    /**
+     * axis.isBoolean( true ); // true
+     */
+    export function isBoolean(elem: any): boolean;
+
+    /**
+     * axis.isNumber( 1 ); // true
+     */
+    export function isNumber(elem: any): boolean;
+
+    /**
+     * axis.isNull( null ); // true
+     */
+    export function isNull(elem: any): boolean;
+
+    /**
+     * axis.isUndefined(); // true
+     */
+    export function isUndefined(elem: any): boolean;
+
+}

--- a/src/axis.d.ts
+++ b/src/axis.d.ts
@@ -1,0 +1,68 @@
+// Type definitions for axis.js
+// Project: axis.js
+// Project by: toddmotto
+// Definitions by: glitch452
+
+/**
+ * Usage: import axis from 'axis.js';
+ */
+declare namespace axis {
+
+    /**
+     * axis.type( "item" ); // "String"
+     */
+    export function type(elem: any): string;
+
+    /**
+     * axis.isArray( [] ); // true
+     */
+    export function isArray(elem: any): boolean;
+
+    /**
+     * axis.isObject( {} ); // true
+     */
+    export function isObject(elem: any): boolean;
+
+    /**
+     * axis.isString( '' ); // true
+     */
+    export function isString(elem: any): boolean;
+
+    /**
+     * axis.isDate( new Date() ); // true
+     */
+    export function isDate(elem: any): boolean;
+
+    /**
+     * axis.isRegExp( /test/i ); // true
+     */
+    export function isRegExp(elem: any): boolean;
+
+    /**
+     * axis.isFunction( function () {} ); // true
+     */
+    export function isFunction(elem: any): boolean;
+
+    /**
+     * axis.isBoolean( true ); // true
+     */
+    export function isBoolean(elem: any): boolean;
+
+    /**
+     * axis.isNumber( 1 ); // true
+     */
+    export function isNumber(elem: any): boolean;
+
+    /**
+     * axis.isNull( null ); // true
+     */
+    export function isNull(elem: any): boolean;
+
+    /**
+     * axis.isUndefined(); // true
+     */
+    export function isUndefined(elem: any): boolean;
+
+}
+
+export = axis;

--- a/src/axis.js
+++ b/src/axis.js
@@ -14,14 +14,14 @@
 
   var types = 'Array Object String Date RegExp Function Boolean Number Null Undefined'.split(' ');
 
-  function type() {
-    return Object.prototype.toString.call(this).slice(8, -1);
+  axis.type = function(item) {
+    return Object.prototype.toString.call(item).slice(8, -1);
   }
 
   for (var i = types.length; i--;) {
     axis['is' + types[i]] = (function (self) {
       return function (elem) {
-        return type.call(elem) === self;
+        return axis.type(elem) === self;
       };
     })(types[i]);
   }

--- a/test/spec/axis-spec.js
+++ b/test/spec/axis-spec.js
@@ -83,6 +83,30 @@ describe('axis', function () {
     });
   });
 
+  describe('axis.type', function () {
+    var mockArr, mockObj, mockStr, mockDate, mockRegExp, mockFunc, mockBool, mockNum;
+    beforeEach(function () {
+      mockArr = [];
+      mockObj = {};
+      mockStr = "";
+      mockDate = new Date();
+      mockRegExp = /test/i;
+      mockFunc = (function(){});
+      mockBool = true;
+      mockNum = 1;
+    });
+    it('should return a string describing the type', function () {
+      expect(axis.type(mockArr)).toBe("Array");
+      expect(axis.type(mockObj)).toBe("Object");
+      expect(axis.type(mockStr)).toBe("String");
+      expect(axis.type(mockDate)).toBe("Date");
+      expect(axis.type(mockRegExp)).toBe("RegExp");
+      expect(axis.type(mockFunc)).toBe("Function");
+      expect(axis.type(mockBool)).toBe("Boolean");
+      expect(axis.type(mockNum)).toBe("Number");
+    });
+  });
+
   // PhantomJS [object DOMWindow] bug causing these to fail!
   // http://stackoverflow.com/questions/14218670/why-are-null-and-undefined-of-the-type-domwindow
   // describe('axis.isNull', function () {


### PR DESCRIPTION
Created an axis.d.ts TypeScript Type Definition file.  This enables axis to be used in a typescript file using the recommended 'import' syntax, instead of using 'require'.  
The Type Definition file allows TypeScript to recognize the functions available within axis.  
Axis can be imported in TypeScript using: import axis from 'axis.js';

Added axis.type() as an internal function with minimal modifications thanks to agrublev (https://github.com/agrublev/).  

The readme was updated with the new function and usage information.  

Tests were added but not run automatically, but the code has been tested manually.  

The axis.min.js file has not been updated.  